### PR TITLE
#57 : Vaciar lista y diferenciar supermercados

### DIFF
--- a/FoodCheck/Web/static/css/product_details.css
+++ b/FoodCheck/Web/static/css/product_details.css
@@ -10,8 +10,6 @@
     margin-top: 6%;
     margin-bottom: 3%;
 
-    
-
     display: flex;
     flex-wrap: nowrap;
 }

--- a/FoodCheck/Web/static/css/shopping_list.css
+++ b/FoodCheck/Web/static/css/shopping_list.css
@@ -22,7 +22,7 @@
 }
 
 .supermercados {
-    color: #545454;
+    color: black;
     font-weight: normal;
 }
 
@@ -40,6 +40,30 @@
     width:90%;
 }
 
+button.vaciar {
+  background-color: rgb(68, 0, 0);
+  color: white;
+  width: 20%;
+
+  border-radius: 33px;
+
+  font-size: 120%;
+  margin: 0 auto;
+}
+
+button.supermercado {
+  background-color: #07644A;
+  color: white;
+  width: 60%;
+
+  border-radius: 33px;
+  
+  padding-bottom: 0.3%;
+  margin: 0 auto;
+  font-size: 250%;
+  font-weight: bold;
+}
+
 #button-row{
     justify-content: center;
 }
@@ -47,35 +71,38 @@
 h1.title {
     color: black;
     font-weight: bold;
+    font-size: 300%;
     letter-spacing: -2px;
+    margin-bottom: 2%;
   }
 
-  .row {
-    margin-top: 5%;
-  }
+.row {
+  margin-top: 5%;
+}
 
-  .tarjeta-usuario {
-    background-color: bisque;
-    border-radius: 15px;
-    border-style: solid;
-    border-color: black;
-    padding: 10px;
-    box-shadow: 0px 0px 10px gray;
-    display: flex;
-    align-items: center;
-    margin-left: 20px;
-  }
+div.contador-productos {
+  width: 33%;
+  margin: 0 auto;
+  margin-bottom: 2%;
+}
+
+.tarjeta-usuario {
+  background-color: bisque;
+  border-radius: 15px;
+  box-shadow: 0px 0px 10px gray;
+  align-items: center;
+}
   
-  .tarjeta-usuario img {
-    width: 50px;
-    height: 50px;
-    border-radius: 50%;
-    margin-right: 10px;
-  }
-  
-  .tarjeta-usuario h2 {
-    margin: 0;
-    font-size: 20px;
-    font-weight: bold;
-    color: #333;
-  }
+.tarjeta-usuario img {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  margin-right: 10px;
+}
+
+.tarjeta-usuario h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: bold;
+  color: #333;
+}

--- a/FoodCheck/Web/templates/shopping_list.html
+++ b/FoodCheck/Web/templates/shopping_list.html
@@ -6,27 +6,38 @@
 {% endblock %}
 
 {% block body %}
+
+<div class="row">
+    <h1 class="title text-center">Tu lista de la compra</h1>
+</div>
   
 {% if productos_agrupados_por_supermercado.items|length != 0 %}
-<div class="row">
-    <div class="col-md-4">
-        <div class="tarjeta-usuario">
-            <ul style="list-style-type: none;">
-                {% for supermercado, numero in num_productos_por_supermercado.items %}
-                <li><b>Numero de Productos del {{supermercado}}: {{numero}}</b></li>
-                {% endfor %}
-            </ul>
+<div class="row text-center">
+    <div class="contador-productos col-md-6">
+        <div class="card tarjeta-usuario">
+            {% for supermercado, numero in num_productos_por_supermercado.items %}
+            <p><b>Numero de Productos del {{supermercado}}: {{numero}}</b></p>
+            {% endfor %}
         </div>
-    </div>  
+    </div>
+
+    <div class="boton-vaciado">
+        <form method="POST" action="/shopping_list/">
+            {% csrf_token %}
+            <button class="vaciar btn btn-primary mb-3" type="submit">Vaciar lista de la compra</button>
+        </form>
+    </div>
 </div>
 {% endif %}
 <div class="container text-center">
     
     <div class="row text-center">
-        <h1 class="title">Tu lista de la compra</h1>
         {% if productos_agrupados_por_supermercado.items|length != 0 %}
             {% for supermercado, productos in productos_agrupados_por_supermercado.items %}
-        <b class="supermercado">{{ supermercado }}</b>
+
+        <button class="supermercado" disabled="true">
+            Productos de {{ supermercado }}
+        </button>
         <div class="row">
             {% for producto in productos %}
             <div class="col-md-4">

--- a/FoodCheck/Web/views.py
+++ b/FoodCheck/Web/views.py
@@ -157,7 +157,7 @@ def allergen_report(request, id_producto):
 
     return render(request, 'allergen_report.html', context)
 
-@require_safe
+@require_http_methods(['GET','POST'])
 @login_required(login_url='authentication:login')
 def shopping_list(request):
     lista_compra = ListaCompra.objects.filter(usuario=request.user)
@@ -166,6 +166,13 @@ def shopping_list(request):
                 lista_compra = ListaCompra.objects.filter(usuario=request.user)
     productos = lista_compra.get().productos.all()
     productos_agrupados_por_supermercado = {} #Diccionario que tiene como clave los supermercados y como valor un conjunto de productos que se vendan en ese supermercado
+
+    #botón vaciar lista
+    if request.method == 'POST':
+        lista_compra_get = lista_compra.get()
+        lista_compra_get.productos.set([])
+        lista_compra_get.save()
+        return redirect('/shopping_list')
 
     for producto in productos:
         for supermercado in producto.supermercados.all():


### PR DESCRIPTION
- Se ha añadido un botón para vaciar los productos de la lista de la compra instantáneamente.
- Se ha reorganizado la página de lista de la compra para estas inclusiones.
- Se ha acentuado la diferencia en cuanto al supermercado de procedencia se refiere.